### PR TITLE
babel in package.json is conflicting. React is asking to remove it. T…

### DIFF
--- a/prometeo-dashboard/package.json
+++ b/prometeo-dashboard/package.json
@@ -15,7 +15,6 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": ">=0.21.1",
-    "babel-loader": "^8.1.0",
     "carbon-components": "10.29.0",
     "carbon-components-react": "7.29.0",
     "carbon-icons": "7.0.7",


### PR DESCRIPTION
…rying ci/cd after removing it.


```
There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "babel-loader": "8.1.0"

Don't try to install it manually: your package manager does it automatically.
However, a different version of babel-loader was detected higher up in the tree:

  /app/node_modules/babel-loader (version: 8.2.2) 

Manually installing incompatible versions is known to cause hard-to-debug issues.

```

Signed-off-by: Upkar Lidder <upkar@pm.me>